### PR TITLE
Make export lists explicit and some documentation haddockification

### DIFF
--- a/language-fortran.cabal
+++ b/language-fortran.cabal
@@ -2,7 +2,10 @@ name:                language-fortran
 version:             0.3
 synopsis:            Fortran lexer and parser, language support, and extensions. 
 description:         
-    Lexer and parser for Fortran roughly supporting standards from FORTRAN 77 to Fortran 2003 (but with some patches and rough edges). Also includes language extension support for units-of-measure typing.
+    Lexer and parser for Fortran roughly supporting standards from
+    FORTRAN 77 to Fortran 2003 (but with some patches and rough
+    edges). Also includes language extension support for
+    units-of-measure typing.
 license:             BSD3
 license-file:        LICENSE
 author:              Jason Dagit, Dominic Orchard, Oleg Oshmyan
@@ -13,6 +16,7 @@ build-type:          Simple
 cabal-version:       >=1.8
 
 library
+  ghc-options:         -Wall
   exposed-modules:     Language.Fortran.Parser,
                        Language.Fortran.Lexer,
                        Language.Fortran.Pretty,

--- a/language-fortran.cabal
+++ b/language-fortran.cabal
@@ -10,10 +10,15 @@ license:             BSD3
 license-file:        LICENSE
 author:              Jason Dagit, Dominic Orchard, Oleg Oshmyan
 maintainer:          dagitj@gmail.com, dom.orchard@gmail.com
+bug-reports:         https://github.com/dagit/language-fortran/issues
 -- copyright:           
 category:            Language
 build-type:          Simple
 cabal-version:       >=1.8
+
+source-repository head
+  type:     git
+  location: https://github.com/dagit/language-fortran
 
 library
   ghc-options:         -Wall

--- a/src/Language/Fortran.hs
+++ b/src/Language/Fortran.hs
@@ -1,10 +1,19 @@
--- 
--- Fortran.hs  - 
+{-# LANGUAGE DeriveFunctor, DeriveDataTypeable #-}
+-- |
 -- Based on FortranP.hs from Parameterized Fortran by Martin Erwig.
 --
-
-{-# LANGUAGE DeriveFunctor, DeriveDataTypeable #-}
-
+-- Language definition for Fortran (covers a lot of standards, but still incomplete)
+--
+-- The AST is parameterised by type variable p which allows all nodes
+-- of the AST to be annotated. The default annotation is (). This is
+-- useful for analysis.  The 'Tagged' type class provides the function
+-- @tag :: d a -> a@ to extract these annotations.
+--
+-- Furthermore, many nodes of the tree have a 'SrcSpan' which is the
+-- start and end locations of the syntax in the source file (including
+-- whitespace etc.)  This is useful for error reporting and
+-- refactoring.  The 'Span' type class provides the function @srcSpan
+-- :: d a -> SrcSpan@ which which extracts the span (where possible)
 module Language.Fortran where
 
 --------------------------------------------------------------------------
@@ -20,18 +29,6 @@ import Data.List
 -- import Language.Haskell.Syntax (SrcLoc(..))
 
 -----------------------------------------------------------------------------------
--- Language definition for Fortran (covers a lot of standards, but still incomplete)
---
---  The AST is parameterised by type variable p which allows all nodes of the AST
---  to be annotated. The default annotation is (). This is useful for analysis. 
---    The 'Tagged' type class provides the function 'tag :: d a -> a' to 
---    extract these annotations.
-
---  Furthermore, many nodes of the tree have a 'SrcSpan' which is the start and end
---  locations of the syntax in the source file (including whitespace etc.)
---  This is useful for error reporting and refactoring. 
---    The 'Span' type class provides the function 'srcSpan :: d a -> SrcSpan' which
---    which extracts the span (where possible)
 
 -----------------------------------------------------------------------------------
 

--- a/src/Language/Fortran.hs
+++ b/src/Language/Fortran.hs
@@ -24,14 +24,10 @@ import Data.Generics -- Typeable class and boilerplate generic functions
                      -- All AST nodes are members of 'Data' and 'Typeable' so that
                      -- data type generic programming can be done with the AST
 
-import Data.Maybe
-import Data.List
--- import Language.Haskell.Syntax (SrcLoc(..))
 
 -----------------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------------
-
 
 data SrcLoc = SrcLoc {
                 srcFilename :: String,

--- a/src/Language/Fortran.hs
+++ b/src/Language/Fortran.hs
@@ -46,9 +46,11 @@ type SrcSpan = (SrcLoc, SrcLoc)
 
 type Variable = String
 
-type ProgName = String               -- Fortran program names
+-- | Fortran program names
+type ProgName = String
 
-data SubName p  = SubName p String   -- Fortran subroutine names
+-- | Fortran subroutine names
+data SubName p  = SubName p String
                  | NullSubName p
                  deriving (Show, Functor, Typeable, Data, Eq)
  
@@ -63,7 +65,8 @@ data ArgName  p = ArgName p String
 -- Syntax defintions
 --
 
-data Arg      p = Arg p (ArgName p) SrcSpan -- the src span denotes the end of the arg list before ')'
+-- | The src span denotes the end of the arg list before ')'
+data Arg      p = Arg p (ArgName p) SrcSpan
                   deriving (Show, Functor, Typeable, Data, Eq)
 
 data ArgList  p = ArgList p (Expr p)
@@ -83,15 +86,17 @@ data ProgUnit  p = Main      p SrcSpan                      (SubName p)  (Arg p)
                 | IncludeProg p SrcSpan (Decl p) (Maybe (Fortran p))
                 deriving (Show, Functor, Typeable, Data, Eq)
 
+-- | Implicit none or no implicit 
 data Implicit p = ImplicitNone p | ImplicitNull p 
-                -- implicit none or no implicit 
                 deriving (Show, Functor, Typeable, Data, Eq)
 
-type Renames = [(Variable, Variable)] -- renames for "use"s 
+-- | renames for "use"s 
+type Renames = [(Variable, Variable)]
 
 data UseBlock p = UseBlock (Uses p) SrcLoc deriving (Show, Functor, Typeable, Data, Eq)
 
-data Uses p  = Use p (String, Renames) (Uses p) p  -- (second 'p' let's you annotate the 'cons' part of the cell)
+-- | (second 'p' let's you annotate the 'cons' part of the cell)
+data Uses p  = Use p (String, Renames) (Uses p) p
                 | UseNil p deriving (Show, Functor, Typeable, Data, Eq)
 
              --       use's     implicit  decls  stmts

--- a/src/Language/Fortran/Lexer.x
+++ b/src/Language/Fortran/Lexer.x
@@ -2,7 +2,8 @@
 module Language.Fortran.Lexer (
     Token(..)
   , AlexReturn(..)
-  , alexScan  
+  , alexScan
+  , alexScanTokens
   , lexer
   , lexer'
   ) where

--- a/src/Language/Fortran/Lexer.x
+++ b/src/Language/Fortran/Lexer.x
@@ -1,5 +1,11 @@
 {
-module Language.Fortran.Lexer where
+module Language.Fortran.Lexer (
+    Token(..)
+  , AlexReturn(..)
+  , alexScan  
+  , lexer
+  , lexer'
+  ) where
 
 import Data.Char
 import Language.Fortran

--- a/src/Language/Fortran/Parser.y
+++ b/src/Language/Fortran/Parser.y
@@ -378,11 +378,11 @@ declaration_construct_p
 declaration_construct :: { Decl A0 }
 declaration_construct
   : srcloc type_spec_p attr_spec_list '::' entity_decl_list  
-  {% (getSrcSpan $1) >>= (\s -> return $ if isEmpty (fst $3) 
+  {% (getSrcSpan $1) >>= (\s -> return $ if null (fst $3) 
 					 then Decl () s $5 ((BaseType () (fst3 $2) (snd $3) (snd3 $2) (trd3 $2)))
 			                 else Decl () s $5 ((ArrayT ()  (fst $3) (fst3 $2) (snd $3) (snd3 $2) (trd3 $2)))) }
   | srcloc type_spec_p attr_spec_list entity_decl_list  
-  {% (getSrcSpan $1) >>= (\s -> return $ if isEmpty (fst $3) 
+  {% (getSrcSpan $1) >>= (\s -> return $ if null (fst $3) 
 					     then Decl () s $4 ((BaseType () (fst3 $2) (snd $3) (snd3 $2) (trd3 $2)))
 			     	             else Decl () s $4 ((ArrayT () (fst $3) (fst3 $2) (snd $3) (snd3 $2) (trd3 $2)))) }
   | interface_block				      { $1 }
@@ -706,7 +706,7 @@ component_def_stmt :: { Decl A0 }
 component_def_stmt
   : srcloc type_spec_p component_attr_spec_list '::' entity_decl_list  
   {% (getSrcSpan $1) >>= (\s -> return $ 
-		     if isEmpty (fst $3) 
+		     if null (fst $3) 
 		     then Decl () s $5 ((BaseType () (fst3 $2) (snd $3) (snd3 $2) (trd3 $2)))
 		     else Decl () s $5 ((ArrayT () (fst $3) (fst3 $2) (snd $3) (snd3 $2) (trd3 $2)))) }
 
@@ -1877,11 +1877,6 @@ cmpNames x "" z                        = return x
 cmpNames (SubName a x) y z | x==y      = return (SubName a x)
                            | otherwise = parseError (z ++ " name \""++x++"\" does not match \""++y++"\" in end " ++ z ++ " statement\n")
 cmpNames s y z                       = parseError (z ++" names do not match\n")
-
-					   
-isEmpty :: [a] -> Bool
-isEmpty [] = True
-isEmpty _  = False
 
 expr2array_spec (Bound _ _ e e') = (e, e') -- possibly a bit dodgy- uses undefined
 expr2array_spec e = (NullExpr () (srcSpan e) , e)

--- a/src/Language/Fortran/Parser.y
+++ b/src/Language/Fortran/Parser.y
@@ -1,5 +1,17 @@
 {
-module Language.Fortran.Parser  where
+module Language.Fortran.Parser (
+    parser
+  , include_parser
+    -- * Helpers
+  , fst3
+  , snd3
+  , trd3
+  , fst4
+  , snd4
+  , trd4
+  , frh4
+  )
+  where
 
 import Language.Fortran
 import Language.Fortran.PreProcess

--- a/src/Language/Fortran/PreProcess.hs
+++ b/src/Language/Fortran/PreProcess.hs
@@ -31,12 +31,8 @@ program is transformed to:
 module Language.Fortran.PreProcess where
 
 import Text.ParserCombinators.Parsec hiding (spaces)
-import Text.ParserCombinators.Parsec.Expr
-import qualified Text.ParserCombinators.Parsec.Token as Token
-import Text.ParserCombinators.Parsec.Language
 import System.Environment
 
-import Debug.Trace
 
 num = many1 digit
 small = lower <|> char '_'

--- a/src/Language/Fortran/PreProcess.hs
+++ b/src/Language/Fortran/PreProcess.hs
@@ -28,7 +28,10 @@ program is transformed to:
 >       17 end do
 >     end do
 -}
-module Language.Fortran.PreProcess where
+module Language.Fortran.PreProcess (
+    pre_process
+  , parseExpr
+  ) where
 
 import Text.ParserCombinators.Parsec hiding (spaces)
 import System.Environment

--- a/src/Language/Fortran/PreProcess.hs
+++ b/src/Language/Fortran/PreProcess.hs
@@ -1,30 +1,33 @@
-{-
+{-|
 
-The following provides a string -> string preprocessor for Fortran programs that deals with
-label-delimited 'do'-'continue' blocks of FORTRAN 77 era. With a traditional LR(1) parser, these are
-not easily (or not at all) parsable. Consider the valid FORTRAN 77 code:
+The following provides a string → string preprocessor for Fortran
+programs that deals with label-delimited @do@-@continue@ blocks of
+FORTRAN 77 era. With a traditional LR(1) parser, these are not easily
+(or not at all) parsable. Consider the valid FORTRAN 77 code:
 
-     do j = 1,5
-       do 17 i=1,10
-         print *,i      
-       17 continue
-     end do 
+>     do j = 1,5
+>       do 17 i=1,10
+>         print *,i
+>       17 continue
+>     end do
 
-Here the 'continue' acts as an 'end do' (not as a usual 'continue' statement) because it is labelled with the same
-label '17' as the 'do' statement which starts the block. Parsing this requires arbitrary look-ahead (e.g., LR(infinity))
-which is provided by the following parsec parser, but not by the 'happy' parser generator. 
+Here the \'continue\' acts as an \'end do\' (not as a usual
+\'continue\' statement) because it is labelled with the same label
+\'17\' as the \'do\' statement which starts the block. Parsing this
+requires arbitrary look-ahead (e.g., LR(infinity)) which is provided
+by the following parsec parser, but not by the \'happy\' parser
+generator.
 
-This pre processor is currently quite heavy handed. It replaces 'continue' in the above program with 'end do'. E.g., 
-the above program is transformed to:
+This pre processor is currently quite heavy handed. It replaces
+\'continue\' in the above program with \'end do\'. E.g., the above
+program is transformed to:
 
-     do j = 1,5
-       do 17 i=1,10
-         print *,i      
-       17 end do
-     end do 
-
+>     do j = 1,5
+>       do 17 i=1,10
+>         print *,i
+>       17 end do
+>     end do
 -}
-
 module Language.Fortran.PreProcess where
 
 import Text.ParserCombinators.Parsec hiding (spaces)


### PR DESCRIPTION
I've made export lists explicit. Without them all internal values generated by allex/happy are exported and it becomes essentially impossible to discover what is in fact useful 

I also make parts of comments visible in haddock and linked this repository in cabal file. 
